### PR TITLE
タスク編集機能の追加

### DIFF
--- a/src/components/modules/TodoItem.vue
+++ b/src/components/modules/TodoItem.vue
@@ -2,7 +2,7 @@
   <input type="checkbox" />
   {{ todo.content }}
   <button @click="$emit('remove', index)">削除</button>
-  <button @click="edit">編集</button>
+  <button @click="$emit('edit',index)">編集</button>
 </template>
 <script>
 import { defineComponent } from "vue";
@@ -17,7 +17,7 @@ export default defineComponent({
       required: false,
     },
   },
-  emits: ["remove"],
+  emits: ["remove",'edit'],
   setup() {},
 });
 </script>

--- a/src/components/modules/TodoItem.vue
+++ b/src/components/modules/TodoItem.vue
@@ -2,6 +2,7 @@
   <input type="checkbox" />
   {{ todo.content }}
   <button @click="$emit('remove', index)">削除</button>
+  <button @click="edit">編集</button>
 </template>
 <script>
 import { defineComponent } from "vue";

--- a/src/components/modules/TodoList.vue
+++ b/src/components/modules/TodoList.vue
@@ -5,7 +5,7 @@
       v-for="(todo, index) in todos"
       :key="index"
     >
-      <TodoItem :todo="todo" :index="index" @remove="remove" />
+      <TodoItem :todo="todo" :index="index" @remove="remove" @edit="edit" />
     </li>
   </div>
 </template>
@@ -24,13 +24,21 @@ export default defineComponent({
   },
   setup(props) {
     const remove = (index) => {
-      //インデックス番目から、1つの要素を削除
       props.todos.splice(index, 1);
       localStorage.removeItem("todoList");
       localStorage.setItem("todoList", JSON.stringify(props.todos));
     };
+
+    const edit = (index) => {
+      // props.todos.splice(index,1)
+      let contents = window.prompt("タスクを入力してください", "");
+      props.todos.splice(index,1,{content:contents, isDone:false})
+      localStorage.removeItem("todoList");
+      localStorage.setItem("todoList", JSON.stringify(props.todos));
+    }
     return {
       remove,
+      edit,
     };
   },
 });


### PR DESCRIPTION
# やったこと
- 編集ボタンの追加
- 編集機能の実装（DOM、ローカルストレージの双方は同時更新）

# 編集機能の詳細
以下の流れで処理が行われる。

1. ローカル上のtodos変数のindex番目の配列から、選択されたcontents項目の内容を削除する
2. 変更後のタスク内容を入力する入力ダイアログを表示させ、入力内容をcontent変数に代入する。
3. ローカル上のtodos変数のindex番目の配列のcontents項目に、content変数の中身を代入。
4. ローカルストレージ上のtodos項目を全削除する
5. ローカルストレージ上に新たにtodos項目を追加する（ローカル上のtodosと同内容が追加される）

#11 remove